### PR TITLE
Auto-registration NelmioApiDocBundle during enable bundle

### DIFF
--- a/src/SimpleRESTAdapterBundle.php
+++ b/src/SimpleRESTAdapterBundle.php
@@ -17,8 +17,11 @@ use Pimcore\Extension\Bundle\Installer\InstallerInterface;
 use Pimcore\Extension\Bundle\PimcoreBundleAdminClassicInterface;
 use Pimcore\Extension\Bundle\Traits\BundleAdminClassicTrait;
 use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
+use Pimcore\HttpKernel\Bundle\DependentBundleInterface;
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+use Nelmio\ApiDocBundle\NelmioApiDocBundle;
 
-final class SimpleRESTAdapterBundle extends AbstractPimcoreBundle implements PimcoreBundleAdminClassicInterface
+final class SimpleRESTAdapterBundle extends AbstractPimcoreBundle implements DependentBundleInterface, PimcoreBundleAdminClassicInterface
 {
     use BundleAdminClassicTrait;
     use PackageVersionTrait;
@@ -51,5 +54,10 @@ final class SimpleRESTAdapterBundle extends AbstractPimcoreBundle implements Pim
     protected function getComposerPackageName(): string
     {
         return self::PACKAGE_NAME;
+    }
+
+    public static function registerDependentBundles(BundleCollection $collection): void
+    {
+        $collection->addBundle(new NelmioApiDocBundle());
     }
 }


### PR DESCRIPTION
As I see you have configration for  NelmioApiDocBundle, but for run it properly,  I need enable NelmioApiDocBundle and manage by bundle order. As I see Pimcore has way how to manage that and  implementation DependentBundleInterface will fix and no need extra steps for setup.
Doc: https://pimcore.com/docs/platform/Pimcore/Extending_Pimcore/Bundle_Developers_Guide/Bundle_Collection#bundle-dependencies
Example: https://github.com/pimcore/advanced-object-search/blob/5.x/src/AdvancedObjectSearchBundle.php#L103-L108

Please review,