### PR TITLE
Filter fix: index field type is text, not keyword

### DIFF
--- a/src/Controller/BaseEndpointController.php
+++ b/src/Controller/BaseEndpointController.php
@@ -38,7 +38,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 abstract class BaseEndpointController extends FrontendController
 {
     protected const OPERATOR_MAP = [
-        '$and' => BoolQuery::MUST,
+        '$and' => BoolQuery::FILTER,
         '$not' => BoolQuery::MUST_NOT,
         '$or' => BoolQuery::SHOULD,
     ];

--- a/src/Transformer/FilterFieldNameTransformer.php
+++ b/src/Transformer/FilterFieldNameTransformer.php
@@ -16,6 +16,6 @@ class FilterFieldNameTransformer implements FilterFieldNameTransformerInterface
 {
     public function transform(string $field): string
     {
-        return 'metaData.'.$field.'.keyword';
+        return 'metaData.'.$field;
     }
 }


### PR DESCRIPTION

Filters in Tree endpoint were working when the field type was.
```
"FileType": {
  "type": "text",
  "fields": {
    "keyword": {
      "type": "keyword",
      "ignore_above": 256
    }
  }
}
```

Now, the field type is:
```
"FileType": {
  "type": "keyword",
  "fields": {
    "analyzed": {
      "type": "text",
      "term_vector": "yes",
      "analyzer": "datahub_ngram_analyzer",
      "search_analyzer": "datahub_whitespace_analyzer"
    }
  }
}
```