### PR TITLE
Wrapping "CI -HUB Settings" to fieldset on "Profile" tab

### DIFF
--- a/src/Resources/public/pimcore/js/userTab.js
+++ b/src/Resources/public/pimcore/js/userTab.js
@@ -36,7 +36,7 @@ pimcore.plugin.simpleRestAdapterBundle.user.profile = Class.create(pimcore.setti
             this.ciHubLoadPanel().then(res => {
                 this.cihub = res;
             }).then(res => {
-                this.currentItems.insert(0, this.getPanel());
+                this.currentItems.insert(1, this.getPanel());
             });
             this.panel = new Ext.Panel({
                 id: "my_profile",
@@ -86,31 +86,34 @@ pimcore.plugin.simpleRestAdapterBundle.user.profile = Class.create(pimcore.setti
             defaults: {
                 labelWidth: 200,
             },
-            title: t('CI-HUB Settings'),
-            items: [
-                {
-                    xtype: 'fieldcontainer',
-                    layout: 'hbox',
-                    items: [
-                        apikeyField,
-                        {
-                            xtype: 'button',
-                            width: 32,
-                            style: 'margin-left: 8px',
-                            iconCls: 'pimcore_icon_clear_cache',
-                            handler: () => {
-                                apikeyField.setValue(generateToken(32));
+            items: [{
+                xtype: 'fieldset',
+                title: t('CI-HUB Settings'),
+                items: [
+                    {
+                        xtype: 'fieldcontainer',
+                        layout: 'hbox',
+                        items: [
+                            apikeyField,
+                            {
+                                xtype: 'button',
+                                width: 32,
+                                style: 'margin-left: 8px',
+                                iconCls: 'pimcore_icon_clear_cache',
+                                handler: () => {
+                                    apikeyField.setValue(generateToken(32));
+                                },
                             },
-                        },
-                        {
-                            xtype: 'button',
-                            text: t("save"),
-                            handler: this.save.bind(this),
-                            iconCls: "pimcore_icon_accept"
-                        },
-                    ],
-                },
-            ],
+                            {
+                                xtype: 'button',
+                                text: t("save"),
+                                handler: this.save.bind(this),
+                                iconCls: "pimcore_icon_accept"
+                            },
+                        ],
+                    },
+                ]
+            }],
         });
 
         return this.deliverySettingsForm;


### PR DESCRIPTION
Hi,

For getting consistent view in user "Profile" added 2 small things:
1. Changed position for "CI -HUB Settings" and it's moved after main default settings
2. Wrapped to fieldset for consitent form view

  
![Screenshot 2024-04-12 at 13 11 27](https://github.com/BrandOriented/PimcoreCiHubConnector/assets/5318027/382f02ae-15df-42e1-a481-f326aca51e76)

Please review,